### PR TITLE
removal of RPath in CMake for FCCSW

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,8 +5,6 @@ ${MAINDIR}
 ${MAINDIR}/spdlog
 ${CMAKE_CURRENT_SOURCE_DIR}
 )
-message(STATUS "Found podio: ${ROOT_LIBRARIES}")
-
 
 add_executable(example_simple example_simple.cpp PythiaConnector.cpp )
 target_compile_definitions(example_simple PRIVATE WITHSORT=1)
@@ -25,7 +23,6 @@ target_link_libraries(example_pdebug papas ${ROOT_LIBRARIES} datamodel datamodel
 
 add_executable(example_plot example_plot.cpp  PythiaConnector.cpp )
 target_link_libraries(example_plot papas ${ROOT_LIBRARIES} datamodel datamodelDict podio utilities)
-
 
 #todo fix this
 #add_executable(example_gun example_gun.cpp )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,7 @@ ${MAINDIR}
 ${MAINDIR}/spdlog
 ${CMAKE_CURRENT_SOURCE_DIR}
 )
+message(STATUS "Found podio: ${ROOT_LIBRARIES}")
 
 
 add_executable(example_simple example_simple.cpp PythiaConnector.cpp )
@@ -24,6 +25,7 @@ target_link_libraries(example_pdebug papas ${ROOT_LIBRARIES} datamodel datamodel
 
 add_executable(example_plot example_plot.cpp  PythiaConnector.cpp )
 target_link_libraries(example_plot papas ${ROOT_LIBRARIES} datamodel datamodelDict podio utilities)
+
 
 #todo fix this
 #add_executable(example_gun example_gun.cpp )

--- a/examples/PythiaConnector.cpp
+++ b/examples/PythiaConnector.cpp
@@ -11,7 +11,7 @@
 #include "papas/reconstruction/PapasManager.h"
 #include "papas/reconstruction/PapasManager.h"
 
-#include "datamodel/CaloClusterCollection.h"
+//#include "datamodel/CaloClusterCollection.h"
 #include "datamodel/EventInfoCollection.h"
 #include "datamodel/ParticleCollection.h"
 #include "utilities/ParticleUtils.h"
@@ -166,6 +166,7 @@ void PythiaConnector::writeParticlesROOT(const char* fname, const papas::Particl
   writer.finish();
 }
 
+/*
 void PythiaConnector::writeClustersROOT(const char* fname, const papas::Clusters& clusters) {
 
   podio::ROOTWriter writer(fname, &m_store);
@@ -217,7 +218,7 @@ void PythiaConnector::AddClustersToEDM(const papas::Clusters& papasClusters, fcc
     p3.z = c.second.position().Z();
   }
 }
-
+*/
 /*void PythiaConnector::readClustersROOT(unsigned int eventNo, papas::PapasManager& papasManager) {
 
   const fcc::ParticleCollection* ptcs(nullptr);

--- a/examples/example_simple.cpp
+++ b/examples/example_simple.cpp
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
     }
 
     // testing (move elsewhere)
-    pythiaConnector.writeClustersROOT("simpleeg.root", papasManager.event().clusters("em"));
+    //pythiaConnector.writeClustersROOT("simpleeg.root", papasManager.event().clusters("em"));
 
     // produce papas display
     TApplication tApp("theApp", &argc, argv);

--- a/papas/datatypes/src/Cluster.cpp
+++ b/papas/datatypes/src/Cluster.cpp
@@ -10,7 +10,7 @@ double Cluster::s_maxEnergy = 0;
 
 Cluster::Cluster(double energy, const TVector3& position, double size_m, uint32_t index, IdCoder::ItemType type,
                  char subtype)
-    : m_id(IdCoder::makeId(index, type, subtype, fmax(0, energy))), m_position(position), m_subClusters({}) {
+    : m_id(IdCoder::makeId(index, type, subtype, fmax(0, energy))), m_position(position) {
   setSize(size_m);
   setEnergy(energy);
 }

--- a/papas/display/src/GDetectorElement.cpp
+++ b/papas/display/src/GDetectorElement.cpp
@@ -33,8 +33,8 @@ GDetectorElement::GDetectorElement(std::shared_ptr<const DetectorElement> detEle
     double radius = elem.radius();
     double dz = elem.z();
 
-    m_circles.push_back(TEllipse(0., 0., radius, radius));
-    m_boxes.push_back(TBox(-dz, -radius, dz, radius));
+    m_circles.push_back({0., 0., radius, radius});
+    m_boxes.push_back({-dz, -radius, dz, radius});
   }
 
   // Choose color according to which element it is
@@ -59,8 +59,8 @@ GDetectorElement::GDetectorElement(std::shared_ptr<const DetectorElement> detEle
 
 GDetectorElement::GDetectorElement(double radius, double dz) {
 
-  m_circles.push_back(TEllipse(0., 0., radius, radius));
-  m_boxes.push_back(TBox(-dz, -radius, dz, radius));
+  m_circles.push_back({0., 0., radius, radius});
+  m_boxes.push_back({-dz, -radius, dz, radius});
 
   // Choose color according to which element it is
   int color = 0;

--- a/papas/display/src/GDetectorElement.cpp
+++ b/papas/display/src/GDetectorElement.cpp
@@ -33,8 +33,8 @@ GDetectorElement::GDetectorElement(std::shared_ptr<const DetectorElement> detEle
     double radius = elem.radius();
     double dz = elem.z();
 
-    m_circles.push_back(std::move(TEllipse(0., 0., radius, radius)));
-    m_boxes.push_back(std::move(TBox(-dz, -radius, dz, radius)));
+    m_circles.push_back(TEllipse(0., 0., radius, radius));
+    m_boxes.push_back(TBox(-dz, -radius, dz, radius));
   }
 
   // Choose color according to which element it is
@@ -59,8 +59,8 @@ GDetectorElement::GDetectorElement(std::shared_ptr<const DetectorElement> detEle
 
 GDetectorElement::GDetectorElement(double radius, double dz) {
 
-  m_circles.push_back(std::move(TEllipse(0., 0., radius, radius)));
-  m_boxes.push_back(std::move(TBox(-dz, -radius, dz, radius)));
+  m_circles.push_back(TEllipse(0., 0., radius, radius));
+  m_boxes.push_back(TBox(-dz, -radius, dz, radius));
 
   // Choose color according to which element it is
   int color = 0;

--- a/papas/graphtools/src/EventRuler.cpp
+++ b/papas/graphtools/src/EventRuler.cpp
@@ -11,18 +11,18 @@ Distance EventRuler::distance(Identifier id1, Identifier id2) const {
   // figure out the object types and then call ClusterCluster or ClusterTrack distance measures
   if (IdCoder::isCluster(id1) && IdCoder::isCluster(id2))
     if (IdCoder::type(id1) == IdCoder::type(id2))
-      return std::move(clusterClusterDistance(id1, id2));
+      return clusterClusterDistance(id1, id2);
     else  // hcal ecal not linked
       return Distance();
   else if (IdCoder::isTrack(id2) && IdCoder::isCluster(id1))
-    return std::move(clusterTrackDistance(id1, id2));
+    return clusterTrackDistance(id1, id2);
   else if (IdCoder::isTrack(id1) && IdCoder::isCluster(id2))
-    return std::move(clusterTrackDistance(id2, id1));
+    return clusterTrackDistance(id2, id1);
   else if (IdCoder::isTrack(id1) && IdCoder::isTrack(id2))
-    return std::move(Distance());
+    return Distance();
   std::cout << IdCoder::type(id1) << ":" << IdCoder::type(id2) << std::endl;
   throw "Distance between ids could not be computed";
-  return std::move(Distance());
+  return Distance();
 }
 
 Distance EventRuler::clusterClusterDistance(Identifier id1, Identifier id2) const {

--- a/papaslib/CMakeLists.txt
+++ b/papaslib/CMakeLists.txt
@@ -1,23 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 
 # use, i.e. don't skip the full RPATH for the build tree
-SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+SET(CMAKE_SKIP_BUILD_RPATH  TRUE)
 
-# when building, don't use the install RPATH already
-# (but later on when installing)
+# when building, don't use the install RPATH 
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE) 
-
-SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
-# add the automatically determined parts of the RPATH
-# which point to directories outside the build tree to the install RPATH
-SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
-# the RPATH to be used when installing, but only if it's not a system directory
-LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-IF("${isSystemDir}" STREQUAL "-1")
-   SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-ENDIF("${isSystemDir}" STREQUAL "-1")
 
 include_directories(
 ${CMAKE_SOURCE_DIR}

--- a/tests/unittest.cpp
+++ b/tests/unittest.cpp
@@ -445,7 +445,7 @@ TEST_CASE("BlockSplitter") {
   // create history nodes
   Nodes historyNodes;
   for (auto id : ids)
-    historyNodes.emplace(id, std::move(PFNode(id)));
+    historyNodes.emplace(id, PFNode(id));
 
   Nodes emptyNodes;
   Blocks blocks;


### PR DESCRIPTION
This pull request is to remove use of RPATH in CMAKE. This is needed for Papas to be included in FCCSW.

Other minor things included are
(1) removal of std::move which gave compiler warnings following upgrade to Xcode 8.
(2) commenting out of CaloClusterCollection in an example.

Joschka has requested retagging following the pull request.